### PR TITLE
fix: disable HTML escaping in mustache template rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,17 @@ export default class SlsPlugin {
    */
   replaceOnContext(config) {
     let context = this.buildContext();
+
+    // Disable HTML escaping since we're rendering configuration, not HTML
+    // This prevents special characters like '/' from being encoded as '&#x2F;'
+    const originalEscape = mustache.escape;
+    mustache.escape = (text) => text;
+
     let replaced = mustache.render(context, config);
+
+    // Restore original escape function
+    mustache.escape = originalEscape;
+
     let ctxObj = JSON.parse(replaced);
 
     this.contextFields.forEach((key) => {


### PR DESCRIPTION
## Problem

Mustache by default HTML-escapes all values when rendering templates to prevent XSS attacks in web contexts. However, this plugin renders **serverless configuration** (not HTML), so HTML escaping causes issues with special characters in configuration values.

### The Issue

The most problematic case is **EventBridge ARNs** which contain `/` characters that were being encoded as `&#x2F;`, causing CloudFormation validation failures during deployment.

**Example:**
```yaml
# PKL generates:
USER_TRACKING_EVENT_BUS_ARN: arn:aws:events:us-east-2:123456789:event-bus/user-tracking-dev

# But after {{pkl:USER_TRACKING_EVENT_BUS_ARN}} replacement:
eventBus: arn:aws:events:us-east-2:123456789:event-bus&#x2F;user-tracking-dev
```

**CloudFormation Error:**
```
CREATE_FAILED: Resource handler returned message: "1 validation error detected: 
Value 'arn:aws:events:us-east-2:123456789:event-bus&#x2F;user-tracking-dev' at 
'eventBusName' failed to satisfy constraint: Member must satisfy regular expression pattern..."
```

## Solution

Temporarily disable HTML escaping during configuration rendering by overriding `mustache.escape`, then restore the original escape function after rendering is complete.

### Changes

Modified the `replaceOnContext()` method in `index.js`:
- Store the original `mustache.escape` function
- Replace it with a pass-through function `(text) => text` that doesn't escape
- Render the configuration
- Restore the original escape function

This ensures:
- ✅ Configuration values are not HTML-escaped
- ✅ No side effects on other code that might use Mustache
- ✅ All special characters (/, &, <, >, ", ') are preserved correctly

## Testing

Verified the fix works correctly with EventBridge ARN containing `/`:
```yaml
# Before fix:
eventBus: arn:aws:events:us-east-2:123456789:event-bus&#x2F;user-tracking-dev

# After fix:
eventBus: arn:aws:events:us-east-2:123456789:event-bus/user-tracking-dev
```

Deployment now succeeds without CloudFormation validation errors.

## Impact

This fix affects all `{{pkl:...}}` template replacements. Since the plugin is used for configuration rendering (not HTML rendering), disabling HTML escaping is the correct behavior and won't introduce any security issues.